### PR TITLE
Don't use minification

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo mv hugo /usr/local/bin
 
       - name: 🛠️ Build
-        run: hugo --minify
+        run: hugo
 
       - name: 🔑 Install SSH Key
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,7 +49,7 @@ jobs:
           # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
-        run: hugo --minify
+        run: hugo
       - name: 📦 Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
Minification results in the following bug:
![image](https://user-images.githubusercontent.com/8635304/197363827-cf68c5cb-b54e-4fbf-ac57-8fce08913a4f.png)

Where the correct version is:
![image](https://user-images.githubusercontent.com/8635304/197363841-f3eac838-544b-44e2-9943-2d726c18f7d5.png)

This happens because we're using spaces that have an influence on layout (which hugo is removing), rather than CSS.

Total transferred on loading home page:
Minified: 	2432439 B
Unminified: 2438081 B (+5.6 KB)

Note this is the amount transferred according to the chrome dev tools, so this is before decompression. The total resources was ~2.8 MB. For visitors where resources could be served from cache, the amount transferred was ~230 KB.