### PR TITLE
CI: Bump actions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ✨ Setup Hugo
         env:


### PR DESCRIPTION
**Purpose:**
Node.js 12 actions are deprecated. The versions of the actions involved have been updated in this PR.
(Same reason as: ScottPlot/ScottPlot#2255)

**Details:**
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**PS:**
whoops, I forgot to open a PR in the repository here.