### PR TITLE
layout: remove article frame

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,7 +2,9 @@ name: Website
 
 on:
   workflow_dispatch:
-  push:
+  push: # only runs on commits to main branch (typically after a merge)
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/content/index_.md
+++ b/content/index_.md
@@ -14,7 +14,7 @@ lastmod: 2022-03-29
 **ScottPlot is a free and open-source plotting library for .NET** that makes it easy to interactively display large datasets. Line plots, bar charts, pie graphs, scatter plots, and more can be created with just a few lines of code.
 
 <a href='cookbook'>
-  <img src='/images/scottplot.gif' class="d-block mx-auto my-4" />
+  <img src='/images/scottplot.gif' class="d-block mx-auto my-5" />
 </a>
 
 ## Quickstart

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -111,35 +111,50 @@
 
 </head>
 
-<body class="bg-light">
+<body>
 
     <!-- menu bar -->
     <div style="background-color: #67217A;" class="">
 
-        <div class="d-flex pt-3">
-            <div class="ms-4 me-3 my-1">
-                <a href="/">
-                    <img class="" src='/images/brand/favicon.svg' width="56" height="56" />
-                </a>
-            </div>
-            <div class="mt-1">
-                <a class="text-light lh-1" href="/" style="font-size: 1.8em;">
-                    ScottPlot.NET
-                </a>
-                <div class="">
-                    {{ partial "github-info.html" . }}
+        <div class="text-center mx-auto" style="max-width: 1000px;">
+            <div class="d-flex pt-3 ">
+                <div class="ms-3 me-3 my-1">
+                    <a href="/">
+                        <img class="" src='/images/brand/favicon.svg' width="56" height="56" />
+                    </a>
+                </div>
+                <div class="mt-1">
+                    <a class="text-light lh-1" href="/" style="font-size: 1.8em;">
+                        ScottPlot.NET
+                    </a>
+                    <div class="">
+                        {{ partial "github-info.html" . }}
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <nav class="py-2">
-            {{ partial "menu.html" . }}
-        </nav>
+            <nav class="py-2">
+                {{ partial "menu.html" . }}
+            </nav>
+        </div>
     </div>
+
+    <header class="px-3 bg-light border-bottom py-3">
+        <div class="mx-auto px-3" style="max-width: 1000px;">
+            <div class="fs-1 fw-light lh-1 mt-2">
+                <a href="{{ .Permalink }}" class="text-dark">
+                    {{ .Title | markdownify }}
+                </a>
+            </div>
+            <div class="fs-5 fw-lighter lh-1 mt-2">
+                {{ .Description | markdownify }}
+            </div>
+        </div>
+    </header>
 
     <!-- main container -->
     <div class="container-fluid p-0" style="position: relative; max-width: 1000px;">
-        <main class="my-5">
+        <main class="mb-5">
             {{ block "main" . }}
             {{ end }}
         </main>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,26 +2,11 @@
 
 {{ partial "post-warnings.html" . }}
 
-<header class="px-3">
-    <div class="fs-1 fw-light lh-1 mt-2">
-        <a href="{{ .Permalink }}" class="text-dark">
-            {{ .Title | markdownify }}
-        </a>
-    </div>
-    <div class="fs-5 fw-lighter lh-1 mt-2">
-        {{ .Description | markdownify }}
-    </div>
-</header>
-
-<article class="bg-light shadow rounded my-3">
+<article class="my-3">
     <div class="p-3 rounded bg-white">
         {{ .Content | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)"
             `<a href="#${2}">${1}</a> ${3}` | safeHTML }}
     </div>
 </article>
-
-<div class="p-2" style="opacity: .3;">
-    {{ partial "post-meta.html" . }}
-</div>
 
 {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,4 +1,4 @@
-<ul class="nav nav-pills px-2">
+<ul class="nav nav-pills px-0">
 
     <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="/quickstart" id="navbarDropdown" role="button"


### PR DESCRIPTION
This PR explores whether pages may look better if we stop trying to frame articles to make it obvious that they are editable markdown files on GitHub

![image](https://user-images.githubusercontent.com/4165489/209388922-38e759ec-6bce-4bc3-a761-3d2c42295543.png)